### PR TITLE
if no interface is specified, use the dbus interface by default

### DIFF
--- a/src/plugins/ipmi_intf.c
+++ b/src/plugins/ipmi_intf.c
@@ -93,6 +93,9 @@ extern struct ipmi_intf ipmi_dbus_intf;
 #endif
 
 struct ipmi_intf * ipmi_intf_table[] = {
+#ifdef IPMI_INTF_DBUS
+	&ipmi_dbus_intf,
+#endif
 #ifdef IPMI_INTF_OPEN
 	&ipmi_open_intf,
 #endif
@@ -123,9 +126,6 @@ struct ipmi_intf * ipmi_intf_table[] = {
 #endif
 #ifdef IPMI_INTF_USB
 	&ipmi_usb_intf,
-#endif
-#ifdef IPMI_INTF_DBUS
-	&ipmi_dbus_intf,
 #endif
 	NULL
 };


### PR DESCRIPTION
This is a patch that should only be on openbmc, not sent upstream
because the dbus interface is really only an openbmc thing.

Signed-off-by: Vernon Mauery <vernon.mauery@linux.intel.com>